### PR TITLE
Update for search_engine_icon_in_searchbar.uc.js

### DIFF
--- a/scripts/search_engine_icon_in_searchbar.uc.js
+++ b/scripts/search_engine_icon_in_searchbar.uc.js
@@ -3,22 +3,33 @@
 // Feature: search button shows current search engines icon (like with old search)
 // base on 'alternative_searchbar.uc.js'
 
-setTimeout(function(){
+var tries = 30;
+var init = function() {
+  // Sometimes the search interface wasn't created in time. Retry (up to 30 times) until it does.
+  try {
+	document.getElementById("searchbar").currentEngine;
+  } catch(e) {
+	if (--tries > 0) {
+	  setTimeout(init, 1000);
+	}
+  }
+
   try {
 	var searchbar = document.getElementById("searchbar");
 
 	updateStyleSheet();
 
-	// setIcon function taken from browsers internal 'searchbar.js' file and added modifications
-	searchbar.setIcon = function(element, uri) {
-	  element.setAttribute("src", uri);
+	// Override updateDisplay() from browsers internal 'searchbar.js' file to also update the icon
+	var oldUpdateDisplay = searchbar.updateDisplay;
+	searchbar.updateDisplay = function() {
+	  oldUpdateDisplay.call(this);
 	  updateStyleSheet();
 	};
 
 	// main style sheet
 	function updateStyleSheet() {
 	  var sss = Components.classes["@mozilla.org/content/style-sheet-service;1"].getService(Components.interfaces.nsIStyleSheetService);
-	
+
 	  var uri = Services.io.newURI("data:text/css;charset=utf-8," + encodeURIComponent(' \
 		.searchbar-search-button .searchbar-search-icon { \
 		  list-style-image: url('+document.getElementById("searchbar").currentEngine.iconURI.spec+') !important; \
@@ -33,5 +44,5 @@ setTimeout(function(){
 	};
 
   } catch(e) {}
-
-},1000);
+}
+setTimeout(init, 1000);


### PR DESCRIPTION
Firefox 77 removed the call to setIcon() that this was hooking. We can
hook updateDisplay() instead, which should probably still work with
earlier versions too.

Also, I've noticed that the script doesn't like to properly run. It
turns out that the 1000ms delay at the start is sometimes not enough, so
let's catch the exception and retry a few times.

Fixes Aris-t2/CustomJSforFx#33