### PR TITLE
Fixes #82 - fixed user script loader for Firefox 115+

### DIFF
--- a/method 2/firefox/config.js
+++ b/method 2/firefox/config.js
@@ -1,17 +1,12 @@
 // config.js
-const Cu = Components.utils;
 
 try {
-
-  Cu.import("resource://gre/modules/Services.jsm");
-  Cu.import("resource://gre/modules/osfile.jsm");
+  Cu.importGlobalProperties(['PathUtils']);
 
   if (!Services.appinfo.inSafeMode) {
-		
-	Services.scriptloader.loadSubScript(
-	  OS.Path.toFileURI(OS.Path.join(OS.Constants.Path.profileDir,
-		"./chrome/userChrome/userChromeJS.js")), this, "UTF-8");
-		
-  };
-
-} catch(e) {};
+    Services.scriptloader.loadSubScript(
+      PathUtils.toFileURI(PathUtils.join(PathUtils.profileDir,
+      './chrome/userChrome/userChromeJS.js')), this, 'UTF-8'
+    );
+  }
+} catch (e) {}

--- a/method 2/profile/userChrome/userChromeJS.js
+++ b/method 2/profile/userChrome/userChromeJS.js
@@ -1,6 +1,8 @@
 // main.js
 
-Cu.import("resource://gre/modules/FileUtils.jsm");
+const { FileUtils } = ChromeUtils.importESModule(
+  'resource://gre/modules/FileUtils.sys.mjs'
+);
 
 var UserChrome_js = {
 
@@ -13,11 +15,11 @@ var UserChrome_js = {
   observe: function(aSubject, aTopic, aData) {
     switch (aTopic) {
       case "final-ui-startup":
-        var ucFilePath = OS.Path.join(OS.Constants.Path.profileDir, "chrome", "userChrome.js");
+        var ucFilePath = PathUtils.join(PathUtils.profileDir, "chrome", "userChrome.js");
         var ucFile = new FileUtils.File(ucFilePath);
         if (ucFile.exists() && ucFile.isFile()) {
-          this.utilFileURI = OS.Path.toFileURI(OS.Path.join(OS.Constants.Path.profileDir, "./chrome/userChrome/userChromeJSutilities.js"));
-          this.ucFileURI = OS.Path.toFileURI(ucFilePath);
+          this.utilFileURI = PathUtils.toFileURI(PathUtils.join(PathUtils.profileDir, "./chrome/userChrome/userChromeJSutilities.js"));
+          this.ucFileURI = PathUtils.toFileURI(ucFilePath);
         };
         Services.obs.removeObserver(this, "final-ui-startup");
         break;


### PR DESCRIPTION
Fixes #82 

@Aris-t2 This should fix the user script loader for Firefox 115+. I think it should work in the current stable release as well but I didn't have the time to verify that. Feel free to change whatever you need to change if you have to support older Firefox versions like Firefox ESR 102.