### PR TITLE
Performance improvement suggestion for 2 userscripts

### DIFF
--- a/scripts/favicon_in_urlbar.uc.js
+++ b/scripts/favicon_in_urlbar.uc.js
@@ -37,27 +37,28 @@ var FaviconInUrlbar = {
 	// update script every time tab attributes get modified (switch/open tabs/windows)
 	document.addEventListener("TabAttrModified", updateIcon, false);
 	document.addEventListener('TabSelect', updateIcon, false);
-	document.addEventListener('TabOpen', updateIcon, false);
 	document.addEventListener('TabClose', updateIcon, false);
-	document.addEventListener('load', updateIcon, false);
-	document.addEventListener("DOMContentLoaded", updateIcon, false);
+	// document.addEventListener('TabOpen', updateIcon, false);
+	// document.addEventListener('load', updateIcon, false);
+	// document.addEventListener("DOMContentLoaded", updateIcon, false);
+	
 
+	function updateIcon(e) {
+		if (e && e.target.getAttribute('selected') !== 'true') return; // don't listen to non-selected tabs
 
-	function updateIcon() {
+		setTimeout(function(){ // timeout fixes wrong icon detection in some cases
 		
-	 setTimeout(function(){ // timeout fixes wrong icon detection in some cases
-	  
-	  // get current tabs favicon
-	  var favicon_in_urlbar = gBrowser.selectedTab.image;
-	  
-	  // if current tab offers no icon, use selected icon (icon_for_pages_without_favicon)
-	  if(!gBrowser.selectedTab.image || gBrowser.selectedTab.image == null)
-		if(!icon_for_pages_without_favicon) favicon_in_urlbar = brand;
-		  else favicon_in_urlbar = icon_for_pages_without_favicon;
-		  
-	  document.querySelector('#favimginurlbar').style.listStyleImage = "url("+favicon_in_urlbar+")";
-	  
-	 },100);
+		// get current tabs favicon
+		var favicon_in_urlbar = gBrowser.selectedTab.image;
+		
+		// if current tab offers no icon, use selected icon (icon_for_pages_without_favicon)
+		if(!gBrowser.selectedTab.image || gBrowser.selectedTab.image == null)
+			if(!icon_for_pages_without_favicon) favicon_in_urlbar = brand;
+			else favicon_in_urlbar = icon_for_pages_without_favicon;
+			
+		document.querySelector('#favimginurlbar').style.listStyleImage = "url("+favicon_in_urlbar+")";
+		
+		},100);
 
 	}
 

--- a/scripts/tab_label_in_urlbar.uc.js
+++ b/scripts/tab_label_in_urlbar.uc.js
@@ -18,14 +18,22 @@
 	updateLabel();
   
 	// catch cases where tab title can change
-	document.addEventListener("TabAttrModified", updateLabel, false);
+	document.addEventListener('TabAttrModified', updateLabel, false);
 	document.addEventListener('TabSelect', updateLabel, false);
-	document.addEventListener('TabOpen', updateLabel, false);
 	document.addEventListener('TabClose', updateLabel, false);
-	document.addEventListener('load', updateLabel, false);
-	document.addEventListener("DOMContentLoaded", updateLabel, false);
+	// document.addEventListener('TabOpen', updateLabel, false);
+	// document.addEventListener('load', updateLabel, false);
+	// document.addEventListener("DOMContentLoaded", updateLabel, false);
   
-	function updateLabel() {
+	function updateLabel(e) {
+		if (e) {
+			if (e.target.getAttribute('selected') !== 'true') return; // don't listen to non-selected tabs
+
+			if (e.target._fullLabel || e.target.label) {
+				tablabel.setAttribute("value",  e.target._fullLabel || e.target.label);
+				return;
+			}
+		}
 	  tablabel.setAttribute("value",gBrowser.selectedBrowser.contentTitle);
 	}
 	


### PR DESCRIPTION
During my testing of scripts `favicon_in_urlbar.uc.js` and `tab_label_in_urlbar.uc.js` I figured out, that `DOMContentLoaded`, `load` and `TabOpen` event listeners are not really neccessary for scripts to function. Basically, 99% of cases are covered by `TabAttrModified` event listener (if not all)  — at least in the current Firefox version I tested (v115). 

Moreover, by removing `TabOpen` listener and adding a check to react only to selected tabs changes, scripts became significally easier on browser startup. Without these changes they processed whatever many tabs user had automatically restored on browser startup — each sending few `TabOpen` and `TabAttrModified` events. 

I guess, the only downside is — `tab_label_in_urlbar.uc.js` will temporary show url in the label widget for new tabs which are still loading and don't have any label yet. 